### PR TITLE
updated from feedback on ui integration

### DIFF
--- a/lib/teams/teams.js
+++ b/lib/teams/teams.js
@@ -142,8 +142,12 @@ export class Teams {
       })
   }
 
-  static updateTeamUser({ id, role }) {
-    return Put(updateTeamUserEndpoint, { id }, Auth.appendHeaders(), { role })
+  static updateTeamUser({ someid, role, status }) {
+    return Put(updateTeamUserEndpoint, undefined, Auth.appendHeaders(), {
+      someid,
+      role,
+      status,
+    })
       .then(({ data }) => {
         return data.data
       })

--- a/lib/teams/teams.test.js
+++ b/lib/teams/teams.test.js
@@ -139,8 +139,13 @@ describe('Teams', () => {
 
   describe('Update Team User', () => {
     test('should update the role of a user on a team', () => {
+      const someid = 'cd98e4e1-6926-4989-8ef8-f326cd5956fc'
       const expectedRes = {
-        data: { id: 'cd98e4e1-6926-4989-8ef8-f326cd5956fc', role: 'Admin' },
+        data: {
+          someid,
+          role: 'Admin',
+          status: 'active',
+        },
         meta: {
           total_count: 1,
         },
@@ -148,19 +153,22 @@ describe('Teams', () => {
 
       nock('http://localhost:8001')
         .matchHeader('Authorization', 'bearer soopersecret')
-        .put(
-          `/v1/teamUsers/updateTeamUser?id=cd98e4e1-6926-4989-8ef8-f326cd5956fc`,
-          { role: 'Admin' },
-        )
+        .put(`/v1/teamUsers/updateTeamUser`, {
+          role: 'Admin',
+          someid,
+          status: 'active',
+        })
         .reply(200, expectedRes)
 
       return Teams.updateTeamUser({
-        id: 'cd98e4e1-6926-4989-8ef8-f326cd5956fc',
+        someid: 'cd98e4e1-6926-4989-8ef8-f326cd5956fc',
         role: 'Admin',
+        status: 'active',
       }).then(resp => {
         expect(resp).toEqual({
-          id: 'cd98e4e1-6926-4989-8ef8-f326cd5956fc',
+          someid: 'cd98e4e1-6926-4989-8ef8-f326cd5956fc',
           role: 'Admin',
+          status: 'active',
         })
       })
     })


### PR DESCRIPTION
`id` switched to `someid`