### PR TITLE
Add pagination to get vulns

### DIFF
--- a/lib/vulnerabilities/vulnerabilities.js
+++ b/lib/vulnerabilities/vulnerabilities.js
@@ -17,14 +17,11 @@ export class Vulnerabilities {
       })
   }
 
-  static getVulnerabilities(
-    product,
-    version,
-    pagination = { offset: 0, limit: 10 },
-  ) {
+  static getVulnerabilities(product, version, offset = 0, limit = 10) {
     const params = new URLSearchParams({
-      product: product,
-      ...pagination,
+      product,
+      offset,
+      limit,
     })
 
     if (version !== undefined) {

--- a/lib/vulnerabilities/vulnerabilities.js
+++ b/lib/vulnerabilities/vulnerabilities.js
@@ -17,7 +17,11 @@ export class Vulnerabilities {
       })
   }
 
-  static getVulnerabilities(product, version, pagination) {
+  static getVulnerabilities(
+    product,
+    version,
+    pagination = { offset: 0, limit: 10 },
+  ) {
     const params = new URLSearchParams({
       product: product,
       ...pagination,

--- a/lib/vulnerabilities/vulnerabilities.js
+++ b/lib/vulnerabilities/vulnerabilities.js
@@ -17,9 +17,10 @@ export class Vulnerabilities {
       })
   }
 
-  static getVulnerabilities(product, version) {
+  static getVulnerabilities(product, version, pagination) {
     const params = new URLSearchParams({
       product: product,
+      ...pagination,
     })
 
     if (version !== undefined) {

--- a/lib/vulnerabilities/vulnerabilities.test.js
+++ b/lib/vulnerabilities/vulnerabilities.test.js
@@ -39,7 +39,9 @@ describe('Vulnerabilities', () => {
   describe('GetVulnerabilities', () => {
     test('should get vulnerabilities', () => {
       nock('http://localhost:8001')
-        .get('/v1/vulnerability/getVulnerabilities?product=jdk')
+        .get(
+          '/v1/vulnerability/getVulnerabilities?product=jdk&offset=0&limit=10',
+        )
         .reply(200, { data: expectedVulnerabilities })
 
       return Vulnerabilities.getVulnerabilities('jdk', undefined).then(
@@ -51,7 +53,9 @@ describe('Vulnerabilities', () => {
 
     test('should get vulnerabilities with the version', () => {
       nock('http://localhost:8001')
-        .get('/v1/vulnerability/getVulnerabilities?product=jdk&version=1.0.0')
+        .get(
+          '/v1/vulnerability/getVulnerabilities?product=jdk&version=1.0.0&offset=0&limit=10',
+        )
         .reply(200, { data: expectedVulnerabilitiesVersion })
 
       return Vulnerabilities.getVulnerabilities('jdk', '1.0.0').then(
@@ -63,7 +67,9 @@ describe('Vulnerabilities', () => {
 
     test('should return an empty set on a not found', () => {
       nock('http://localhost:8001')
-        .get('/v1/vulnerability/getVulnerabilities?product=asdf')
+        .get(
+          '/v1/vulnerability/getVulnerabilities?product=asdf&offset=0&limit=10',
+        )
         .reply(200, { data: [] })
 
       return Vulnerabilities.getVulnerabilities('asdf', undefined).then(

--- a/lib/vulnerabilities/vulnerabilities.test.js
+++ b/lib/vulnerabilities/vulnerabilities.test.js
@@ -79,7 +79,7 @@ describe('Vulnerabilities', () => {
       )
     })
 
-    test('should get vulnerabilities with pagination params', () => {
+    test('should get vulnerabilities with default pagination params', () => {
       nock('http://localhost:8001')
         .get(
           '/v1/vulnerability/getVulnerabilities?product=jdk&offset=0&limit=10',
@@ -91,6 +91,21 @@ describe('Vulnerabilities', () => {
         limit: 10,
       }).then(response => {
         expect(response).toEqual(expectedVulnerabilities)
+      })
+    })
+
+    test('should get vulnerabilities with unique pagination params', () => {
+      nock('http://localhost:8001')
+        .get(
+          '/v1/vulnerability/getVulnerabilities?product=jdk&offset=0&limit=1',
+        )
+        .reply(200, { data: [expectedVulnerabilities[0]] })
+
+      return Vulnerabilities.getVulnerabilities('jdk', undefined, {
+        offset: 0,
+        limit: 1,
+      }).then(response => {
+        expect(response).toEqual([expectedVulnerabilities[0]])
       })
     })
   })

--- a/lib/vulnerabilities/vulnerabilities.test.js
+++ b/lib/vulnerabilities/vulnerabilities.test.js
@@ -86,12 +86,11 @@ describe('Vulnerabilities', () => {
         )
         .reply(200, { data: expectedVulnerabilities })
 
-      return Vulnerabilities.getVulnerabilities('jdk', undefined, {
-        offset: 0,
-        limit: 10,
-      }).then(response => {
-        expect(response).toEqual(expectedVulnerabilities)
-      })
+      return Vulnerabilities.getVulnerabilities('jdk', undefined, 0, 10).then(
+        response => {
+          expect(response).toEqual(expectedVulnerabilities)
+        },
+      )
     })
 
     test('should get vulnerabilities with unique pagination params', () => {
@@ -101,12 +100,11 @@ describe('Vulnerabilities', () => {
         )
         .reply(200, { data: [expectedVulnerabilities[0]] })
 
-      return Vulnerabilities.getVulnerabilities('jdk', undefined, {
-        offset: 0,
-        limit: 1,
-      }).then(response => {
-        expect(response).toEqual([expectedVulnerabilities[0]])
-      })
+      return Vulnerabilities.getVulnerabilities('jdk', undefined, 0, 1).then(
+        response => {
+          expect(response).toEqual([expectedVulnerabilities[0]])
+        },
+      )
     })
   })
 })

--- a/lib/vulnerabilities/vulnerabilities.test.js
+++ b/lib/vulnerabilities/vulnerabilities.test.js
@@ -72,6 +72,21 @@ describe('Vulnerabilities', () => {
         },
       )
     })
+
+    test('should get vulnerabilities with pagination params', () => {
+      nock('http://localhost:8001')
+        .get(
+          '/v1/vulnerability/getVulnerabilities?product=jdk&offset=0&limit=10',
+        )
+        .reply(200, { data: expectedVulnerabilities })
+
+      return Vulnerabilities.getVulnerabilities('jdk', undefined, {
+        offset: 0,
+        limit: 10,
+      }).then(response => {
+        expect(response).toEqual(expectedVulnerabilities)
+      })
+    })
   })
 })
 


### PR DESCRIPTION
![Screen Shot 2020-04-09 at 12 19 33 PM 1](https://user-images.githubusercontent.com/9688337/78932492-6cd99480-7a5c-11ea-92c8-a48556951578.png)

Looks like this api can take pagination params, and the server has a default value for pagination. This moves that default value into the request so that the ui can provide those values, like from that image, the vulnerabilities returned should not be 10, it should be 47.