### PR TITLE
Add more endpoints

### DIFF
--- a/lib/reports/reports.js
+++ b/lib/reports/reports.js
@@ -118,6 +118,17 @@ export class Reports {
         throw error
       })
   }
+
+  static getPublicAnalysis(analysisId) {
+    const params = new URLSearchParams({
+      analysis_id: analysisId,
+    })
+    return Get(getPublicAnalysisEndpoint, params)
+      .then(({ data }) => data.data)
+      .catch(error => {
+        throw error
+      })
+  }
 }
 
 const getAnalysisEndpoint = '/v1/report/getAnalysis'
@@ -127,3 +138,4 @@ const getProjectsEndpoint = '/v1/report/getProjects'
 const getPortfolioEndpoint = '/v1/report/getPortfolio'
 const getVulnerabilityListEndpoint = '/v1/report/getVulnerabilityList'
 const getAffectedProjectsEndpoint = '/v1/report/getAffectedProjects'
+const getPublicAnalysisEndpoint = '/v1/report/getPublicAnalysis'

--- a/lib/rulesets/ruleset.structs.js
+++ b/lib/rulesets/ruleset.structs.js
@@ -51,7 +51,7 @@ export const RuleSet = t.struct(
   'RuleSet',
 )
 
-export const Rulesets = t.struct(
+export const RuleSets = t.struct(
   {
     data: t.list(RuleSet),
   },

--- a/lib/rulesets/ruleset.structs.js
+++ b/lib/rulesets/ruleset.structs.js
@@ -42,11 +42,11 @@ export const ProjectHistory = t.struct(
 export const RuleSet = t.struct(
   {
     id: t.String,
-    name: t.String,
-    description: t.String,
-    team_id: t.String,
-    created_at: t.String,
-    rule_ids: t.list(t.String),
+    // name: t.String,
+    // description: t.String,
+    // team_id: t.String,
+    // created_at: t.String,
+    // rule_ids: t.list(t.String),
   },
   'RuleSet',
 )

--- a/lib/rulesets/ruleset.structs.js
+++ b/lib/rulesets/ruleset.structs.js
@@ -38,3 +38,36 @@ export const ProjectHistory = t.struct(
   },
   'ProjectHistory',
 )
+
+export const RuleSet = t.struct(
+  {
+    id: t.String,
+    name: t.String,
+    description: t.String,
+    team_id: t.String,
+    created_at: t.String,
+    rule_ids: t.list(t.String),
+  },
+  'RuleSet',
+)
+
+export const Rulesets = t.struct(
+  {
+    data: t.list(RuleSet),
+  },
+  'RuleSets',
+)
+
+export const Rule = t.struct(
+  {
+    id: t.String,
+    name: t.String,
+    description: t.String,
+    category: t.String,
+    results: t.maybe(t.Object),
+    scan_type: t.String,
+  },
+  'Rule',
+)
+
+export const Rules = t.struct({ data: t.list(Rule) }, 'Rules')

--- a/lib/rulesets/ruleset.structs.js
+++ b/lib/rulesets/ruleset.structs.js
@@ -42,11 +42,11 @@ export const ProjectHistory = t.struct(
 export const RuleSet = t.struct(
   {
     id: t.String,
-    // name: t.String,
-    // description: t.String,
-    // team_id: t.String,
-    // created_at: t.String,
-    // rule_ids: t.list(t.String),
+    name: t.String,
+    description: t.String,
+    team_id: t.String,
+    created_at: t.String,
+    rule_ids: t.list(t.String),
   },
   'RuleSet',
 )

--- a/lib/rulesets/rulesets.js
+++ b/lib/rulesets/rulesets.js
@@ -29,15 +29,12 @@ export class Rulesets {
   }
 
   static getRuleset({ id, teamId }) {
-    const params = new URLSearchParams({ id, team_id: teamId })
-    return Get(getRulesetEndpoint, params, Auth.appendHeaders())
-      .then(({ data }) => {
-        Structs.RuleSet(data.data)
-        return data.data
-      })
-      .catch(error => {
-        throw error
-      })
+    const params = new URLSearchParams({ id: id, team_id: teamId })
+    return Get(getRulesetEndpoint, params, Auth.appendHeaders()).then(
+      ({ data }) => {
+        return data
+      },
+    )
   }
 
   static getRulesets({ teamId }) {

--- a/lib/rulesets/rulesets.js
+++ b/lib/rulesets/rulesets.js
@@ -32,7 +32,7 @@ export class Rulesets {
     const params = new URLSearchParams({ id, team_id: teamId })
     return Get(getRulesetEndpoint, params, Auth.appendHeaders())
       .then(({ data }) => {
-        Structs.Ruleset(data.data)
+        Structs.RuleSet(data.data)
         return data.data
       })
       .catch(error => {
@@ -44,7 +44,7 @@ export class Rulesets {
     const params = new URLSearchParams({ team_id: teamId })
     return Get(getRulesetsEndpoint, params, Auth.appendHeaders())
       .then(({ data }) => {
-        Structs.Rulesets(data)
+        Structs.RuleSets(data)
         return data.data
       })
       .catch(error => {

--- a/lib/rulesets/rulesets.js
+++ b/lib/rulesets/rulesets.js
@@ -1,5 +1,5 @@
 import { Auth } from '../auth/auth'
-import { Get } from '../requests'
+import { Get, Post } from '../requests'
 import * as Structs from './ruleset.structs'
 
 export class Rulesets {
@@ -29,15 +29,54 @@ export class Rulesets {
   }
 
   static getRuleset({ id, teamId }) {
-    const params = new URLSearchParams({ id: id, team_id: teamId })
-    return Get(getRulesetEndpoint, params, Auth.appendHeaders()).then(
-      ({ data }) => {
-        return data
-      },
-    )
+    const params = new URLSearchParams({ id, team_id: teamId })
+    return Get(getRulesetEndpoint, params, Auth.appendHeaders())
+      .then(({ data }) => {
+        Structs.Ruleset(data.data)
+        return data.data
+      })
+      .catch(error => {
+        throw error
+      })
+  }
+
+  static getRulesets({ teamId }) {
+    const params = new URLSearchParams({ team_id: teamId })
+    return Get(getRulesetsEndpoint, params, Auth.appendHeaders())
+      .then(({ data }) => {
+        Structs.Rulesets(data)
+        return data.data
+      })
+      .catch(error => {
+        throw error
+      })
+  }
+
+  static getRules() {
+    return Get(getRulesEndpoint, undefined, Auth.appendHeaders())
+      .then(({ data }) => {
+        Structs.Rules(data)
+        return data.data
+      })
+      .catch(error => {
+        throw error
+      })
+  }
+
+  static createRuleset({ teamId, name, description, ruleIds }) {
+    const body = {
+      team_id: teamId,
+      rule_ids: ruleIds,
+      name,
+      description,
+    }
+    return Post(createRulesetEndpoint, undefined, Auth.appendHeaders(), body)
   }
 }
 
 const getAppliedRuleSetEndpoint = '/v1/ruleset/getAppliedRulesetForProject'
 const getProjectHistoryEndpoint = '/v1/ruleset/getProjectHistory'
 const getRulesetEndpoint = '/v1/ruleset/getRuleset'
+const getRulesetsEndpoint = '/v1/ruleset/getRulesets'
+const getRulesEndpoint = '/v1/ruleset/getRules'
+const createRulesetEndpoint = '/v1/ruleset/createRuleset'

--- a/lib/sessions/sessions.js
+++ b/lib/sessions/sessions.js
@@ -1,4 +1,5 @@
-import { Post } from '../requests'
+import { Auth } from '../auth/auth'
+import { Post, Delete } from '../requests'
 import * as Structs from './sessions.structs'
 
 export class Sessions {
@@ -27,6 +28,16 @@ export class Sessions {
         throw error
       })
   }
+
+  static logout() {
+    return Delete(sessionsLogoutEndpoint, undefined, Auth.appendHeaders())
+      .then(res => res)
+      .catch(error => {
+        throw error
+      })
+  }
 }
 
 const sessionsLoginEndpoint = '/v1/sessions/login'
+
+const sessionsLogoutEndpoint = '/v1/sessions/logout'

--- a/lib/tokens/tokens.js
+++ b/lib/tokens/tokens.js
@@ -52,8 +52,17 @@ export class Tokens {
         throw error
       })
   }
+
+  static refreshToken() {
+    return Get(tokensRefreshTokenEndpoint, undefined, Auth.appendHeaders())
+      .then(res => res)
+      .catch(error => {
+        throw error
+      })
+  }
 }
 
 const tokensGetTokensEndpoint = '/v1/tokens/getTokens'
 const tokensDeleteTokenEndpoint = '/v1/tokens/deleteToken'
 const tokensCreateTokenEndpoint = '/v1/tokens/createToken'
+const tokensRefreshTokenEndpoint = '/v1/tokens/refreshToken'

--- a/lib/users/users.js
+++ b/lib/users/users.js
@@ -74,9 +74,31 @@ export class Users {
         throw error
       })
   }
+
+  static signupAws({
+    customer,
+    teamName,
+    email,
+    name,
+    username,
+    password,
+    passwordConfirmation,
+  }) {
+    const body = {
+      customer,
+      name,
+      team_name: teamName,
+      username,
+      email,
+      password,
+      password_confirmation: passwordConfirmation,
+    }
+    return Post(usersSignupAwsEndpoint, undefined, Auth.appendHeaders(), body)
+  }
 }
 
 const usersGetSelfEndpoint = '/v1/users/getSelf'
 const usersGetUsersEndpoint = '/v1/users/getUsers'
 const usersResetPasswordEndpoint = '/v1/users/resetPassword'
 const usersUpdateUserEndpoint = '/v1/users/updateUser'
+const usersSignupAwsEndpoint = '/v1/users/signupAws'


### PR DESCRIPTION
This has the last remaining api requests that are still in ion-ui.

There will be more work to do after this is merged, like validating that they work as intended, adding tests and struts for documentation. A lot of that will come out of the process of replacing the ion implementation of those endpoints with anion.