### PR TITLE
consistent use of params

### DIFF
--- a/lib/deliveries/deliveries.js
+++ b/lib/deliveries/deliveries.js
@@ -22,7 +22,12 @@ export class Deliveries {
     // required shape of body: team_id, location, region, name, type, access_key, secret_access_key
     // type can be either s3 or grafeas
     // location is required if the type is s3
-    return Post(createDestinationEndpoint, null, Auth.appendHeaders(), body)
+    return Post(
+      createDestinationEndpoint,
+      undefined,
+      Auth.appendHeaders(),
+      body,
+    )
   }
 
   static deleteDestination(id) {

--- a/lib/teams/teams.js
+++ b/lib/teams/teams.js
@@ -65,9 +65,9 @@ export class Teams {
       authorization: token,
     }
 
-    const params = {
+    const params = new URLSearchParams({
       someid: id,
-    }
+    })
 
     return Get(getTeamInviteEndpoint, params, headers)
       .then(({ data }) => data)

--- a/lib/tokens/tokens.js
+++ b/lib/tokens/tokens.js
@@ -4,10 +4,10 @@ import * as Structs from './tokens.structs'
 
 export class Tokens {
   static createToken({ name, cli = true }) {
-    const params = {
+    const params = new URLSearchParams({
       name,
       cli,
-    }
+    })
 
     return Post(
       tokensCreateTokenEndpoint,
@@ -22,9 +22,9 @@ export class Tokens {
   }
 
   static getTokens({ cli = false }) {
-    const params = {
+    const params = new URLSearchParams({
       cli,
-    }
+    })
 
     return Get(tokensGetTokensEndpoint, params, Auth.appendHeaders())
       .then(({ data }) => {
@@ -37,9 +37,7 @@ export class Tokens {
   }
 
   static deleteToken({ id }) {
-    const params = {
-      id,
-    }
+    const params = new URLSearchParams({ id })
 
     return Delete(
       tokensDeleteTokenEndpoint,

--- a/lib/users/users.js
+++ b/lib/users/users.js
@@ -97,7 +97,7 @@ export class Users {
   }
 
   static signupUser(body) {
-    return Post(usersSignupEndpoint, null, Auth.appendHeaders(), body)
+    return Post(usersSignupEndpoint, undefined, Auth.appendHeaders(), body)
   }
 }
 


### PR DESCRIPTION
passing in `null` to any of the api request functions results in the request with a query like `?null=`, but passing in `undefined` gives back an empty string to the `URLSearchParams` constructor.  null might not cause a bug on any of the http requests, but this also gives more consistent use of that argument.