### PR TITLE
[ION-616] noop usage flag

### DIFF
--- a/lib/usage/usage.js
+++ b/lib/usage/usage.js
@@ -2,9 +2,12 @@ import { Auth } from '../auth/auth'
 import { Get } from '../requests'
 
 export class Usage {
-  static info({ teamId }) {
+  static info({ teamId, noOp = false }) {
     const params = new URLSearchParams({ team_id: teamId })
-    return Get(infoEndpoint, params, Auth.appendHeaders())
+    // no operation flag in case usage data isn't present
+    return noOp
+      ? Promise.resolve({ TotalPurchased: -2, TotalUsed: 0 })
+      : Get(infoEndpoint, params, Auth.appendHeaders())
   }
 }
 

--- a/lib/usage/usage.test.js
+++ b/lib/usage/usage.test.js
@@ -19,5 +19,21 @@ describe('Usage', () => {
         expect(res.data).toEqual({ TotalPurchased: 100, TotalUsed: 10 })
       })
     })
+
+    test('should handle a no-op flag, and return the proper response', () => {
+      return Usage.info({ teamId: 'abc', noOp: true }).then(res => {
+        expect(res).toEqual({ TotalPurchased: -2, TotalUsed: 0 })
+      })
+    })
+
+    test('should handle a false no-op flag if present, and return the proper response', () => {
+      nock('http://localhost:8001')
+        .matchHeader('Authorization', 'bearer soopersecret')
+        .get('/v1/usage/info?team_id=abc')
+        .reply(200, { TotalPurchased: 100, TotalUsed: 10 })
+      return Usage.info({ teamId: 'abc', noOp: false }).then(res => {
+        expect(res.data).toEqual({ TotalPurchased: 100, TotalUsed: 10 })
+      })
+    })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ion-channel-anion",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anion-sdk",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "description": "A Node SDK for the Ion Channel API",
   "main": "anion.js",
   "private": false,


### PR DESCRIPTION
- changes `lib/usage/usage.js`, updating `Usage` endpoint to allow a no-op when flag is present. This allows the call to still handle an operation where data isn't present, and it's expected.